### PR TITLE
Cicd

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -88,15 +88,15 @@ jobs:
     - name: Use Dockerfile to build
       uses: redhat-actions/buildah-build@v1
       with:
-        image: earningsbot-arm
+        image: earningsbot
         tag: latest
         dockerfiles: |
           ./Dockerfile
     - name: Push to Dockerhub
       uses: redhat-actions/push-to-registry@v1
       with:
-        image: earningsbot-arm
-        tag: latest
-        registry: ${{ secrets.DOCKERHUB_REPO }}
+        image: earningsbot
+        tag: arm-latest
+        registry: ${{ secrets.DOCKERHUB_USER }}
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_PASS }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -85,14 +85,21 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: earningsbot-linux-arm
-    - name: Use Dockerfile to build
-      #run: buildah bud -f Dockerfile --format oci -t earningsbot:arm-latest --platform=linux/arm .
-      run: buildah bud -f Dockerfile --format oci -t earningsbot:arm-latest --build-arg BASE_IMAGE=arm32v7/debian .
-    - name: Push to Dockerhub
-      uses: redhat-actions/push-to-registry@v1
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      uses: docker/login-action@v1 
       with:
-        image: earningsbot
-        tag: arm-latest
-        registry: ${{ secrets.DOCKERHUB_USER }}
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_PASS }}
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/arm/v7 # Can add more platforms here
+        push: true
+        tags: |
+          ${{ secrets.DOCKERHUB_USER }}/earningsbot:latest

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Push to Dockerhub
       uses: redhat-actions/push-to-registry@v1
       with:
-        image: earningsbot-debian
+        image: earningsbot-arm
         tag: latest
         registry: ${{ secrets.DOCKERHUB_REPO }}
         username: ${{ secrets.DOCKERHUB_USER }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -98,5 +98,5 @@ jobs:
         image: earningsbot-debian
         tag: latest
         registry: ${{ secrets.DOCKERHUB_REPO }}
-        username: ${{ secrets.DOCKERHUBUSER }}
-        password: ${{ secrets.DOCKERHUBPASS }}
+        username: ${{ secrets.DOCKERHUB_USER }}
+        password: ${{ secrets.DOCKERHUB_PASS }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -86,7 +86,8 @@ jobs:
       with:
         name: earningsbot-linux-arm
     - name: Use Dockerfile to build
-      run: buildah bud -f Dockerfile --format oci -t earningsbot:arm-latest --platform=linux/arm .
+      #run: buildah bud -f Dockerfile --format oci -t earningsbot:arm-latest --platform=linux/arm .
+      run: buildah bud -f Dockerfile --format oci -t earningsbot:arm-latest --build-arg BASE_IMAGE=arm32v7/debian .
     - name: Push to Dockerhub
       uses: redhat-actions/push-to-registry@v1
       with:

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -92,11 +92,11 @@ jobs:
         tag: latest
         dockerfiles: |
           ./Dockerfile
-    #- name: Push to Dockerhub
-    #  uses: redhat-actions/push-to-registry@v1
-    #  with:
-    #    image: ${{ env.IMAGE_NAME }}
-    #    tag: ${{ env.TAG }}
-    #    registry: ${{ secrets.QUAY_REPO }}
-    #    username: ${{ secrets.QUAY_USERNAME }}
-    #    password: ${{ secrets.QUAY_TOKEN }}
+    - name: Push to Dockerhub
+      uses: redhat-actions/push-to-registry@v1
+      with:
+        image: earningsbot-debian
+        tag: latest
+        registry: ${{ secrets.DOCKERHUB_REPO }}
+        username: ${{ secrets.DOCKERHUBUSER }}
+        password: ${{ secrets.DOCKERHUBPASS }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -93,6 +93,8 @@ jobs:
         oci: true
         dockerfiles: |
           ./Dockerfile
+        build-args: |
+          platform=linux/arm
     - name: Push to Dockerhub
       uses: redhat-actions/push-to-registry@v1
       with:

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -86,7 +86,7 @@ jobs:
       with:
         name: earningsbot-linux-arm
     - name: Use Dockerfile to build
-      run: buildah bud -f Dockerfile --format docker -t earningsbot:arm-latest --platform=linux/arm .
+      run: buildah bud -f Dockerfile --format oci -t earningsbot:arm-latest --platform=linux/arm .
     - name: Push to Dockerhub
       uses: redhat-actions/push-to-registry@v1
       with:

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -90,6 +90,7 @@ jobs:
       with:
         image: earningsbot
         tag: arm-latest
+        oci: true
         dockerfiles: |
           ./Dockerfile
     - name: Push to Dockerhub

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -86,15 +86,7 @@ jobs:
       with:
         name: earningsbot-linux-arm
     - name: Use Dockerfile to build
-      uses: redhat-actions/buildah-build@v1
-      with:
-        image: earningsbot
-        tag: arm-latest
-        oci: true
-        dockerfiles: |
-          ./Dockerfile
-        build-args: |
-          platform=linux/arm
+      run: buildah bud -f Dockerfile --format docker -t earningsbot:arm-latest --platform=linux/arm .
     - name: Push to Dockerhub
       uses: redhat-actions/push-to-registry@v1
       with:

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -89,7 +89,7 @@ jobs:
       uses: redhat-actions/buildah-build@v1
       with:
         image: earningsbot
-        tag: latest
+        tag: arm-latest
         dockerfiles: |
           ./Dockerfile
     - name: Push to Dockerhub

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/debian
+FROM docker.io/library/debian:buster-slim
 
 # Since we issue http(s) requests, we need to install
 # certificate authority certificates from the

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-ARG BASE_IMAGE=debian
-FROM ${BASE_IMAGE}
-#FROM docker.io/library/debian:buster-slim
+FROM docker.io/library/debian:buster-slim
 
 # Since we issue http(s) requests, we need to install
 # certificate authority certificates from the

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM docker.io/library/debian:buster-slim
+ARG BASE_IMAGE=debian
+FROM ${BASE_IMAGE}
+#FROM docker.io/library/debian:buster-slim
 
 # Since we issue http(s) requests, we need to install
 # certificate authority certificates from the

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/debian:buster-slim
+FROM docker.io/library/debian
 
 # Since we issue http(s) requests, we need to install
 # certificate authority certificates from the


### PR DESCRIPTION
This pipeline adds onto your original linting code. It will now lint and compile in parallel, build binaries for macOS and ARM, and create a working container image from the ARM binary.

NOTE: The last stage of this pipeline pushes to DockerHub to save the container image in the cloud. This stage uses secrets that are not present in the upstream repo. We'll have to add those and then that last pipeline stage will work.